### PR TITLE
keep all headers when resolve headers secret

### DIFF
--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -164,7 +164,7 @@ class ValuesFrom:
         )
         return client.get_secret_value(SecretId=SecretId)['SecretString']
 
-    def resolve_secrect(self, conf: dict) -> dict:
+    def resolve_secret(self, conf: dict) -> dict:
         resolved = {}
         for k, v in conf.items():
             resolved[k] = v
@@ -172,7 +172,7 @@ class ValuesFrom:
                 secret_id = v.get('value_from', '')
                 if secret_id.startswith('arn:aws:secretsmanager:'):
                     resolved[k] = self.get_secret_value_aws(secret_id)
-                # TODO resolve secrect with Azure, GCP, etc.
+                # TODO resolve secret with Azure, GCP, etc.
         return resolved
 
     def get_contents(self):
@@ -190,7 +190,7 @@ class ValuesFrom:
 
         params = dict(
             uri=self.data.get('url'),
-            headers=self.resolve_secrect(self.data.get('headers', {})),
+            headers=self.resolve_secret(self.data.get('headers', {})),
         )
 
         contents = str(self.resolver.resolve(**params))

--- a/tests/data/placebo/get_headers_from_secretsmanager_secret/secretsmanager.GetSecretValue_1.json
+++ b/tests/data/placebo/get_headers_from_secretsmanager_secret/secretsmanager.GetSecretValue_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "ARN": "arn:aws:secretsmanager:us-east-1:644160558196:secret:secretsmanager_secret_string-XSQFTo",
+        "Name": "secretsmanager_secret_string",
+        "VersionId": "9AACC73C-2EC2-4055-B051-BA7039E01A57",
+        "SecretString": "1234567890",
+        "VersionStages": [
+            "AWSCURRENT"
+        ],
+        "CreatedDate": {
+            "__class__": "datetime",
+            "year": 2023,
+            "month": 5,
+            "day": 6,
+            "hour": 18,
+            "minute": 14,
+            "second": 20,
+            "microsecond": 220000
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/terraform/get_headers_from_secretsmanager_secret/main.tf
+++ b/tests/terraform/get_headers_from_secretsmanager_secret/main.tf
@@ -1,0 +1,8 @@
+resource "aws_secretsmanager_secret" "this" {
+  name = "secretsmanager_secret_string"
+}
+
+resource "aws_secretsmanager_secret_version" "this" {
+  secret_id     = aws_secretsmanager_secret.this.id
+  secret_string = "1234567890"
+}

--- a/tests/terraform/get_headers_from_secretsmanager_secret/tf_resources.json
+++ b/tests/terraform/get_headers_from_secretsmanager_secret/tf_resources.json
@@ -1,0 +1,38 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_secretsmanager_secret": {
+            "this": {
+                "arn": "arn:aws:secretsmanager:us-east-1:644160558196:secret:secretsmanager_secret_string-XSQFTo",
+                "description": "",
+                "force_overwrite_replica_secret": false,
+                "id": "arn:aws:secretsmanager:us-east-1:644160558196:secret:secretsmanager_secret_string-XSQFTo",
+                "kms_key_id": "",
+                "name": "secretsmanager_secret_string",
+                "name_prefix": "",
+                "policy": "",
+                "recovery_window_in_days": 30,
+                "replica": [],
+                "rotation_enabled": false,
+                "rotation_lambda_arn": "",
+                "rotation_rules": [],
+                "tags": null,
+                "tags_all": {}
+            }
+        },
+        "aws_secretsmanager_secret_version": {
+            "this": {
+                "arn": "arn:aws:secretsmanager:us-east-1:644160558196:secret:secretsmanager_secret_string-XSQFTo",
+                "id": "arn:aws:secretsmanager:us-east-1:644160558196:secret:secretsmanager_secret_string-XSQFTo|9AACC73C-2EC2-4055-B051-BA7039E01A57",
+                "secret_binary": "",
+                "secret_id": "arn:aws:secretsmanager:us-east-1:644160558196:secret:secretsmanager_secret_string-XSQFTo",
+                "secret_string": "1234567890",
+                "version_id": "9AACC73C-2EC2-4055-B051-BA7039E01A57",
+                "version_stages": [
+                    "AWSCURRENT"
+                ]
+            }
+        }
+    }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -305,8 +305,24 @@ class SchemaTest(CliTest):
                     'headers': {
                         'type': 'object',
                         'patternProperties': {
-                            '': {'type': 'string'},
-                        },
+                            '': {
+                                'oneOf': [
+                                    {'type': 'string'},
+                                    {
+                                        'type': 'object',
+                                        'required': ['value_from'],
+                                        'additionalProperties': 'False',
+                                        'properties': {
+                                            'value_from': {
+                                                'type': 'string',
+                                                'pattern':
+                                                    '^arn:aws:secretsmanager:.+:\\d+:secret:.+$'
+                                            },
+                                        },
+                                    },
+                                ]
+                            }
+                        }
                     },
                 }
             },
@@ -323,8 +339,24 @@ class SchemaTest(CliTest):
                     'headers': {
                         'type': 'object',
                         'patternProperties': {
-                            '': {'type': 'string'},
-                        },
+                            '': {
+                                'oneOf': [
+                                    {'type': 'string'},
+                                    {
+                                        'type': 'object',
+                                        'required': ['value_from'],
+                                        'additionalProperties': 'False',
+                                        'properties': {
+                                            'value_from': {
+                                                'type': 'string',
+                                                'pattern':
+                                                    '^arn:aws:secretsmanager:.+:\\d+:secret:.+$'
+                                            },
+                                        },
+                                    },
+                                ]
+                            }
+                        }
                     },
                 }
             }

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -23,9 +23,8 @@ def test__get_headers_from_string():
         {'session_factory': None, '_cache': None, 'config': Config.empty(account_id=ACCOUNT_ID)}
     )
     values = ValuesFrom({}, mgr)
-    raw_headers = {'x-api-key': '1234567890'}
-    headers = values.resolve_secret(raw_headers)
 
+    headers = values.resolve_secret({'x-api-key': '1234567890'})
     assert len(headers) == 1
     assert headers['x-api-key'] == '1234567890'
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -20,24 +20,11 @@ from pytest_terraform import terraform
 
 def test__get_headers_from_string():
     mgr = Bag(
-        {
-            'session_factory': None,
-            '_cache': None,
-            'config': Config.empty(account_id=ACCOUNT_ID)
-        }
+        {'session_factory': None, '_cache': None, 'config': Config.empty(account_id=ACCOUNT_ID)}
     )
-    values = ValuesFrom(
-        {
-            'url': 'example',
-            'expr': '[].bean',
-            'format': 'json',
-            'headers': {
-                'x-api-key': '1234567890',
-            }
-        },
-        mgr
-    )
-    headers = values._get_headers()
+    values = ValuesFrom({}, mgr)
+    raw_headers = {'x-api-key': '1234567890'}
+    headers = values.resolve_secrect(raw_headers)
 
     assert len(headers) == 1
     assert headers['x-api-key'] == '1234567890'
@@ -46,37 +33,22 @@ def test__get_headers_from_string():
 @terraform('get_headers_from_secretsmanager_secret')
 def test__get_headers_from_secretsmanager_secret(test, get_headers_from_secretsmanager_secret):
     aws_region = 'us-east-1'
-    session_factory = test.replay_flight_data(
-        'get_headers_from_secretsmanager_secret',
-        region=aws_region
-    )
+    sf = test.replay_flight_data('get_headers_from_secretsmanager_secret', region=aws_region)
+    secrect_id = get_headers_from_secretsmanager_secret[
+        'aws_secretsmanager_secret_version.this.arn'
+    ]
+    secrect_string = get_headers_from_secretsmanager_secret[
+        'aws_secretsmanager_secret_version.this.secret_string'
+    ]
 
-    manager = Bag(
-        {
-            'session_factory': session_factory,
-            '_cache': None,
-            'config': Config.empty(account_id=ACCOUNT_ID)
-        }
+    mgr = Bag(
+        {'session_factory': sf, '_cache': None, 'config': Config.empty(account_id=ACCOUNT_ID)}
     )
-    values = ValuesFrom(
-        {
-            'url': 'example',
-            'expr': '[].bean',
-            'format': 'json',
-            'headers': {
-                'x-api-key': {
-                    'value_from': get_headers_from_secretsmanager_secret[
-                        'aws_secretsmanager_secret_version.this.arn']
-                },
-            }
-        },
-        manager
-    )
-    headers = values._get_headers()
+    values = ValuesFrom({}, mgr)
 
+    headers = values.resolve_secrect({'x-api-key': {'value_from': secrect_id}})
     assert len(headers) == 1
-    assert headers['x-api-key'] == get_headers_from_secretsmanager_secret[
-        'aws_secretsmanager_secret_version.this.secret_string']
+    assert headers['x-api-key'] == secrect_string
 
 
 class FakeCache:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -24,7 +24,7 @@ def test__get_headers_from_string():
     )
     values = ValuesFrom({}, mgr)
     raw_headers = {'x-api-key': '1234567890'}
-    headers = values.resolve_secrect(raw_headers)
+    headers = values.resolve_secret(raw_headers)
 
     assert len(headers) == 1
     assert headers['x-api-key'] == '1234567890'
@@ -46,7 +46,7 @@ def test__get_headers_from_secretsmanager_secret(test, get_headers_from_secretsm
     )
     values = ValuesFrom({}, mgr)
 
-    headers = values.resolve_secrect({'x-api-key': {'value_from': secrect_id}})
+    headers = values.resolve_secret({'x-api-key': {'value_from': secrect_id}})
     assert len(headers) == 1
     assert headers['x-api-key'] == secrect_string
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -496,6 +496,36 @@ class SchemaTest(BaseTest):
         errors = list(self.get_validator(data).iter_errors(data))
         self.assertEqual(len(errors), 0)
 
+    def test_value_from_headers(self):
+        secret_arn = 'arn:aws:secretsmanager:us-east-1:123456789012:secret:name-asdfgh'
+        data = {
+            "policies": [
+                {
+                    "name": "example",
+                    "resource": "ec2",
+                    "filters": [
+                        {
+                            'type': 'value',
+                            'key': 'InstanceId',
+                            'op': 'not-in',
+                            'value_from': {
+                                'url': 'example',
+                                'format': 'json',
+                                'headers': {
+                                    'header_1': 'example',
+                                    'header_2': {
+                                        'value_from': secret_arn
+                                    },
+                                },
+                            }
+                        }
+                    ],
+                }
+            ]
+        }
+        errors = list(self.get_validator(data).iter_errors(data))
+        self.assertEqual(len(errors), 0)
+
     def test_mark_for_op(self):
         data = {
             "policies": [


### PR DESCRIPTION
Hi paladin-dranser,

In this PR, the only logic I changed is below, in order to avoid the risk (in the future) of filtering out any headers that are not of type dict or str, and to reserve a slot for other providers. Regarding other changes, they are based on personal preferences, so please feel free to accept or disregard them.
```python
        for k, v in conf.items():
            resolved[k] = v
            if isinstance(v, dict):
                secret_id = v.get('value_from', '')
                if secret_id.startswith('arn:aws:secretsmanager:'):
                    resolved[k] = self.get_secret_value_aws(secret_id)
                # TODO resolve secret with Azure, GCP, etc.
```